### PR TITLE
fix a syntactical error in thc_open_ipv6

### DIFF
--- a/thc-ipv6-lib.c
+++ b/thc-ipv6-lib.c
@@ -2399,7 +2399,7 @@ int thc_open_ipv6() {
   if (thc_socket >= 0)
     return thc_socket;
     
-  if ((getenv("THC_IPV6_RAW") != NULL || getenv("THC_IPV6_RAWMODE") != NULL)
+  if (getenv("THC_IPV6_RAW") != NULL || getenv("THC_IPV6_RAWMODE") != NULL)
     thc_ipv6_rawmode(1);
 
   if ((ptr = getenv("THC_IPV6_VLAN")) != NULL && strlen(ptr) > 0) {


### PR DESCRIPTION
There was an error in compilation
make
gcc -O2 -D_HAVE_SSL   -c -o thc-ipv6-lib.o thc-ipv6-lib.c
thc-ipv6-lib.c: In function ‘thc_open_ipv6’:
thc-ipv6-lib.c:2403:5: error: expected ‘)’ before ‘thc_ipv6_rawmode’
thc_ipv6_rawmode(1);
^
thc-ipv6-lib.c:2573:1: error: expected expression before ‘}’ token
}
^
make: **\* [thc-ipv6-lib.o] Error 1
