### PR TITLE
thc-ipv6.8: update Arturo Borrero Gonzalez email address

### DIFF
--- a/thc-ipv6.8
+++ b/thc-ipv6.8
@@ -295,6 +295,6 @@ thc-ipv6 was written by van Hauser <vh@thc.org> / THC
 The homepage for this toolkit is: http://www.thc.org/thc-ipv6
 .PP
 This manual page was written by Maykel Moya <mmoya@mmoya.org> and
-Arturo Borrero Gonzalez <arturo.borrero.glez@gmail.com>, for the Debian
+Arturo Borrero Gonzalez <arturo@debian.org>, for the Debian
 project (but may be used by others). It's based on previous work by
 Michael Gebetsroither <gebi@grml.org>.


### PR DESCRIPTION
Use a new email address.

Signed-off-by: Arturo Borrero Gonzalez arturo@debian.org
