### PR TITLE
Manpage header typo

### DIFF
--- a/thc-ipv6.8
+++ b/thc-ipv6.8
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH THC-IPv6 ATTACK-TOOLKIT6 8 "Summer 2015"
+.TH THC-IPv6 8 ATTACK-TOOLKIT6 "Summer 2015"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:


### PR DESCRIPTION
From the header description itself:
```
.\" First parameter, NAME, should be all caps
.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
.\" other parameters are allowed: see man(7), man(1)
```

Invert the parameter order.