### PR TITLE
Fix typos

### DIFF
--- a/alive6.c
+++ b/alive6.c
@@ -921,7 +921,7 @@ int main(int argc, char *argv[]) {
     help(argv[0]);
 
   if (slow && ndp_only) {
-    fprintf(stderr, "Error: you can not use the -S and -L options togther!\n");
+    fprintf(stderr, "Error: you can not use the -S and -L options together!\n");
     exit(-1);
   }
 

--- a/dump_dhcp6.c
+++ b/dump_dhcp6.c
@@ -139,7 +139,7 @@ void check_packets(u_char *foo, const struct pcap_pkthdr *header, const unsigned
           break;
         case 2:
           if (j > 0) {
-            printf("    Server Identifier: "); // server identier
+            printf("    Server Identifier: "); // server identifier
             for (k = 0; k < j; k++) {
               printf("%02x", (unsigned char) data[4 + k]);
             }
@@ -151,7 +151,7 @@ void check_packets(u_char *foo, const struct pcap_pkthdr *header, const unsigned
             printf("    Address Offered: %s\n", thc_ipv62notation((unsigned char*)data + 20));
           break;
         case 7:
-          printf("    Prefered value (not implemented)\n"); // prefered value
+          printf("    Preferred value (not implemented)\n"); // preferred value
           break;
         case 13:
         case 19:

--- a/fuzz_dhcpc6.c
+++ b/fuzz_dhcpc6.c
@@ -678,7 +678,7 @@ int main(int argc, char *argv[]) {
   }
 
   if (test_end < test_start) {
-    printf("dont fuck up the command line options!\n");
+    printf("don't fuck up the command line options!\n");
     exit(-1);
   }
 

--- a/thcping6.c
+++ b/thcping6.c
@@ -25,7 +25,7 @@ void help(char *prg, int help) {
   printf("Syntax: %s [-EafqxO] [-e ethertype] [-H t:l:v] [-D t:l:v] [-F dst] [-e ethertype] [-L length] [-N nextheader] [-V version] [-t ttl] [-c class] [-l label] [-d size] [-S port|-U port|-T type -C code] interface src6 dst6 [srcmac [dstmac [data]]]\n\n", prg);
   printf("Options:\n");
   if (help) {
-    printf("  -x              flood mode (doesnt check for replies)\n");
+    printf("  -x              flood mode (doesn't check for replies)\n");
     printf("  -a              add a hop-by-hop header with router alert option.\n");
     printf("  -q              add a hop-by-hop header with quickstart option.\n");
     printf("  -E              send as ethertype IPv4\n");


### PR DESCRIPTION
These typos showed up on lintian while packaging the last version for debian (i'm a member working on the packaging of thc-ipv6). There still may be some typos on comments, i just fixed the ones that appear on the binaries.