### PR TITLE
Fix build with recent glibc (eg: Fedora 27)

### DIFF
--- a/dnsrevenum6.c
+++ b/dnsrevenum6.c
@@ -17,6 +17,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <strings.h>
 #include <string.h>


### PR DESCRIPTION
Include stdint.h in dnsrevenum6.c since uintptr_t is defined there (at least on recent glibc).

Tested system:
Fedora 27, Kernel 4.14.11-300.fc27.x86_64 and glibc-2.26-21.fc27.x86_64

PS. I'm the maintainer of thc-ipv6 Fedora packages.

```
$ grep -n -C 5 'uintptr_t' /usr/include/stdint.h
95-#if __WORDSIZE == 64
96-# ifndef __intptr_t_defined
97-typedef long int             intptr_t;
98-#  define __intptr_t_defined
99-# endif
100:typedef unsigned long int   uintptr_t;
101-#else
102-# ifndef __intptr_t_defined
103-typedef int                 intptr_t;
104-#  define __intptr_t_defined
105-# endif
106:typedef unsigned int                uintptr_t;
107-#endif
108-
109-
110-/* Largest integral types.  */
111-typedef __intmax_t          intmax_t;

```