### PR TITLE
dnsrevenum6: Add missing time header

### DIFF
--- a/dnsrevenum6.c
+++ b/dnsrevenum6.c
@@ -30,6 +30,7 @@
 #include <signal.h>
 #include <ctype.h>
 #include <string.h>
+#include <time.h>
 #include "thc-ipv6.h"
 
 // do not set below 2


### PR DESCRIPTION
Otherwise time() is unavailable under musl.