### PR TITLE
connect6: Change in6_pktinfo check

### DIFF
--- a/connect6.c
+++ b/connect6.c
@@ -23,7 +23,7 @@
 
 #define PROGRAM "connect6"
 
-#ifndef in6_pktinfo
+#ifndef _BSD_SOURCE
 struct in6_pktinfo {
   struct in6_addr ipi6_addr;
   int ipi6_ifindex;


### PR DESCRIPTION
musl does not define in6_pktinfo which causes a redefinition error.

musl checks against _BSD_SOURCE or _GNU_SOURCE. The latter implies the former.