### PR TITLE
More portable 'date -I ' instead of 'date --iso-8601'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ backup:	clean
 	sync
 
 %.8: %
-	@echo .TH $* 8 `date --iso-8601` THC "IPv6 ATTACK TOOLKIT" > $@
+	@echo .TH $* 8 `date -I` THC "IPv6 ATTACK TOOLKIT" > $@
 	@echo .SH NAME >> $@
 	@echo .B $* >> $@
 	@./$*|tail -n +2|sed -e "s#\\./$*#$*#g" -e "s/^Syntax: \?/.SH SYNOPSIS\n/g" -e "s/Options:/.SH OPTIONS\n.nf\n/g" -e "s/^\(.*\):\$$/.SH \1\n/g" >> $@


### PR DESCRIPTION
`date -I` and `date --iso-8601` provide exactly the same output, but the 2nd format isn't supported everywhere (e.g. busybox).