### PR TITLE
Remove K&R function declarations for C23 compatibility

### DIFF
--- a/detect_sniffer6.c
+++ b/detect_sniffer6.c
@@ -27,7 +27,7 @@ void help(char *prg) {
   exit(-1);
 }
 
-void alarming() {
+void alarming(int signal) {
   if (found == 0)
     printf("No packets received, no vulnerable system seems to be sniffing.\n");
   else
@@ -63,7 +63,7 @@ void check_packets(u_char *pingdata, const struct pcap_pkthdr *header,
       printf(" Sniffing host detected: %s\n", thc_ipv62notation(ptr + 8));
       memcpy(doubles[found], thc_ipv62notation(ptr + 8), 16);
       found++;
-      if (oneonly) alarming();
+      if (oneonly) alarming(0);
     }
   }
 }

--- a/thc-ipv6.h
+++ b/thc-ipv6.h
@@ -208,7 +208,7 @@ extern int thc_generate_pkt(char *interface, unsigned char *srcmac,
                             int *pkt_len);
 extern int thc_send_pkt(char *interface, unsigned char *pkt, int *pkt_len);
 extern unsigned char *thc_destroy_packet(unsigned char *pkt);
-extern int            thc_open_ipv6();
+extern int            thc_open_ipv6(char *interface);
 extern int            thc_is_dst_local(char *interface, unsigned char *dst);
 extern int  checksum_pseudo_header(unsigned char *src, unsigned char *dst,
                                    unsigned char type, unsigned char *data,

--- a/thcping6.c
+++ b/thcping6.c
@@ -89,7 +89,7 @@ void help(char *prg, int help) {
   exit(-1);
 }
 
-void alarming() {
+void alarming(int signal) {
   if (done == 0) printf("No packet received, terminating.\n");
   exit(resp_type);
 }


### PR DESCRIPTION
Fixes the following build failures related to C23 using GCC 15 on Fedora Rawhide:

```
thc-ipv6-lib.c:2555:5: error: conflicting types for ‘thc_open_ipv6’; have ‘int(char *)’
 2555 | int thc_open_ipv6(char *interface) {
      |     ^~~~~~~~~~~~~
thc-ipv6.h:211:23: note: previous declaration of ‘thc_open_ipv6’ with type ‘int(void)’
  211 | extern int            thc_open_ipv6();
      |                       ^~~~~~~~~~~~~
```
```
detect_sniffer6.c:140:19: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
  140 |   signal(SIGALRM, alarming);
      |                   ^~~~~~~~
      |                   |
      |                   void (*)(void)
```
```
thcping6.c:648:21: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
  648 |     signal(SIGALRM, alarming);
      |                     ^~~~~~~~
      |                     |
      |                     void (*)(void)
```